### PR TITLE
[Docs] #49 반납 및 불용 신청 테스트용 시드 데이터 추가

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -2,6 +2,9 @@
 
 spring.test.username=dev-user
 
+#flyway
+spring.flyway.out-of-order=true
+
 #database(mysql) should be same this environment variables
 spring.datasource.url=jdbc:mysql://localhost:3306/usto?serverTimezone=Asia/Seoul&characterEncoding=utf8&allowLoadLocalInfile=true
 spring.datasource.username=${DB_USERNAME}

--- a/src/main/resources/db/seed/item/insert_asset_data_for_RTRN_and_DSU.sql
+++ b/src/main/resources/db/seed/item/insert_asset_data_for_RTRN_and_DSU.sql
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * 반납 및 불용 신청 테스트용 데이터 (SEED DATA)
+ *******************************************************************************/
+USE usto;
+
+-- 1. 기존 데이터 전체 삭제 (초기화)
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE `TB_ITEM002M`; -- 물품대장기본
+TRUNCATE TABLE `TB_ITEM002D`; -- 물품대장상세
+TRUNCATE TABLE `TB_ITEM006M`; -- 물품상태이력
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- 2. 공통 환경 변수 설정
+SET @ACQ_ID_TEST = UNHEX('77777777777777777777777777777777');
+SET @ORG_CD_ERICA = '7008277';
+
+-- 3. 대장 기본 (002M) - 총 6개 수량
+INSERT INTO `TB_ITEM002M` (ACQ_ID, G2B_D_CD, QTY, ACQ_AT, ARRG_AT, ORG_CD, ACQ_ARRG_TY, CRE_BY, CRE_AT)
+VALUES (@ACQ_ID_TEST, '25241236', 6, '2026-01-15', '2026-01-16', @ORG_CD_ERICA, 'BUY', 'test-admin', NOW());
+
+-- 4. 대장 상세 (002D)
+INSERT INTO `TB_ITEM002D` (ITM_NO, ACQ_ID, G2B_D_CD, DEPT_CD, OPER_STS, ACQ_UPR, DRB_YR, RMK, ORG_CD, CRE_BY, CRE_AT)
+VALUES
+    -- [반납신청 테스트용: 현재 운용 중]
+    ('M202600001', @ACQ_ID_TEST, '25241236', 'A350', 'OPER', 500000, '5', '반납테스트용(운용)', @ORG_CD_ERICA, 'dev-user', NOW()),
+    ('M202600002', @ACQ_ID_TEST, '25241236', 'A350', 'OPER', 500000, '5', '반납테스트용(운용)', @ORG_CD_ERICA, 'dev-user', NOW()),
+    ('M202600003', @ACQ_ID_TEST, '25241236', 'A350', 'OPER', 500000, '5', '반납테스트용(운용)', @ORG_CD_ERICA, 'dev-user', NOW()),
+
+    -- [불용신청 테스트용: 현재 반납 완료 상태]
+    ('M202600004', @ACQ_ID_TEST, '25241236', 'NONE', 'RTN',  800000, '5', '불용테스트용(반납)', @ORG_CD_ERICA, 'dev-user', NOW()),
+    ('M202600005', @ACQ_ID_TEST, '25241236', 'NONE', 'RTN',  800000, '5', '불용테스트용(반납)', @ORG_CD_ERICA, 'dev-user', NOW()),
+    ('M202600006', @ACQ_ID_TEST, '25241236', 'NONE', 'RTN',  800000, '5', '불용테스트용(반납)', @ORG_CD_ERICA, 'dev-user', NOW());
+
+-- 5. 상태 변경 이력 (006M) 기록
+-- [STEP 1] 1~6번 물품 모두: 최초 취득 등록 이력 (ACQ -> OPER)
+INSERT INTO `TB_ITEM006M` (ITEM_HIS_ID, ITM_NO, PREV_STS, NEW_STS, CHG_RSN, REQ_USR_ID, REQ_AT, APPR_USR_ID, APPR_AT, ORG_CD, CRE_BY, CRE_AT)
+VALUES
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600001', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600002', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600003', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600004', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600005', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600006', 'ACQ', 'OPER', '자산 신규 등록', 'admin', '2026-01-16', 'admin', '2026-01-16', @ORG_CD_ERICA, 'system', NOW());
+
+-- [STEP 2] 4~6번 물품만 추가: 반납 완료 이력 (OPER -> RTN)
+INSERT INTO `TB_ITEM006M` (ITEM_HIS_ID, ITM_NO, PREV_STS, NEW_STS, CHG_RSN, REQ_USR_ID, REQ_AT, APPR_USR_ID, APPR_AT, ORG_CD, CRE_BY, CRE_AT)
+VALUES
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600004', 'OPER', 'RTN', '불용 처리를 위한 사전 반납', 'test-user', '2026-01-20', 'admin', '2026-01-21', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600005', 'OPER', 'RTN', '불용 처리를 위한 사전 반납', 'test-user', '2026-01-20', 'admin', '2026-01-21', @ORG_CD_ERICA, 'system', NOW()),
+    (UNHEX(REPLACE(UUID(), '-', '')), 'M202600006', 'OPER', 'RTN', '불용 처리를 위한 사전 반납', 'test-user', '2026-01-20', 'admin', '2026-01-21', @ORG_CD_ERICA, 'system', NOW());


### PR DESCRIPTION
### ✨ 변경 사항 설명

물품 6개 데이터 생성
- M202600001 ~ 003: 운용(OPER) 상태 물품 (반납 신청 테스트용)
- M202600004 ~ 006: 반납(RTN) 상태 물품 (불용 신청 테스트용)
- 각 물품별 최초 취득 및 상태 변화 이력(006M) 포함

- 실행 시 TB_ITEM002M/D(대장기본/대장상세), TB_ITEM006M(상태이력) 테이블이 **초기화**됩니다
- 에리카 캠퍼스(7008277) 조직 코드로 설정되어 있어서 해당 조직 소속의 사용자로만 테스트 가능합니다

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [x] 테스트 코드 추가 / 수정
- [ ] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제

---

### 🗒️ 참고 사항 (선택)

- 예외 처리가 적용되어 있어, '운용' 상태 물품을 불용 신청하거나 '반납' 상태 물품을 반납 신청할 경우 에러가 발생하도록 구현되어 있습니다

---

### 📷 스크린샷 (선택)

참고로 `GET api/item/returnings`의 결과가 [반납등록목록]이고, 해당 목록에서 한 행을 클릭하여 나오는 [반납물품목록]의 결과가 `GET api/item/returnings/{rtrnMId}/items` 입니다.
[반납등록목록] = 반납 등록 건의 리스트
[반납물품목록] = 반납 한 건에 속한 물품들의 리스트

반납 등록 테스트 시에는 물품번호(예: M202600001)를 넣어서 신청하고,
생성된 반납 건에 대해 수정/삭제/승인요청 등을 테스트할때는 반납 건의 UUID(`rtrnMId`)를 이용해서 실행하시면 됩니다

(불용 신청도 동일)

<img width="1071" height="579" alt="image" src="https://github.com/user-attachments/assets/65b26f2f-1446-4133-bc14-8c3c5f4ab719" />

<img width="482" height="270" alt="image" src="https://github.com/user-attachments/assets/f140fe05-3a1c-4777-a3a3-8341cfec388e" />

<img width="482" height="270" alt="image" src="https://github.com/user-attachments/assets/0ab7f08f-3cfe-4458-8587-942ed769ae93" />
