### PR TITLE
[Refactor] 132 AI architecture and enhance DTO implementation

### DIFF
--- a/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
+++ b/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
@@ -3,6 +3,7 @@ package com.usto.api.ai.common;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequest;
+import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequestToAi;
 import com.usto.api.ai.forecast.presentation.dto.response.AiForecastResponse;
 import com.usto.api.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class AiForecastAdapter {
     private final AiProperties properties;
     private final ObjectMapper objectMapper; // JSON 파싱을 위한 매퍼 추가
 
-    public AiForecastResponse fetchForecastResponse(AiForecastRequest request) {
+    public AiForecastResponse fetchForecastResponse(AiForecastRequestToAi request) {
         // 1. 먼저 String으로 응답을 받아서 로그를 확인
         String rawResponse =
                 aiWebClient.post()
@@ -30,7 +31,8 @@ public class AiForecastAdapter {
                 .bodyValue(request)
                 .retrieve()
                         // 1. 서버 에러(5xx) 처리 - ngrok 장애 등 외부 API 불능 상태 대응
-                        .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        .onStatus(HttpStatusCode::is5xxServerError,
+                                clientResponse ->
                                 clientResponse.bodyToMono(String.class)
                                         .defaultIfEmpty("")
                                         .flatMap(errorBody -> {

--- a/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
+++ b/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
@@ -2,7 +2,6 @@ package com.usto.api.ai.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequest;
 import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequestToAi;
 import com.usto.api.ai.forecast.presentation.dto.response.AiForecastResponse;
 import com.usto.api.common.exception.BusinessException;

--- a/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
+++ b/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
@@ -107,7 +107,6 @@ public class AiForecastAdapter {
 
             // 2. "data" 키에 해당하는 자식 노드만 추출
             JsonNode dataNode = rootNode.get("data");
-        //=====================성공===============================
             if (dataNode != null && !dataNode.isNull()) {
                 AiForecastResponse res = objectMapper.treeToValue(dataNode, AiForecastResponse.class);
                 boolean allEmpty = (res.summary() == null)
@@ -118,6 +117,8 @@ public class AiForecastAdapter {
                     // AI는 성공적으로 응답했지만, 유의미한 분석 결과가 없는 경우를 방지하기 위해 추가 검증
                     throw new BusinessException("AI가 유의미한 분석을 반환하지 않았습니다. 입력 조건을 확인하거나 잠시 후 다시 시도해주세요.");
                 }
+
+                //=====================성공===============================
                 return res; //<- 성공한 결과
             }
         } catch (Exception e) {

--- a/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
+++ b/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
@@ -115,6 +115,7 @@ public class AiForecastAdapter {
                         && (res.chartPortfolio() == null || res.chartPortfolio().isEmpty())
                         && (res.recommendations() == null || res.recommendations().isEmpty());
                 if (allEmpty) {
+                    // AI는 성공적으로 응답했지만, 유의미한 분석 결과가 없는 경우를 방지하기 위해 추가 검증
                     throw new BusinessException("AI가 유의미한 분석을 반환하지 않았습니다. 입력 조건을 확인하거나 잠시 후 다시 시도해주세요.");
                 }
                 return res; //<- 성공한 결과

--- a/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
+++ b/src/main/java/com/usto/api/ai/common/AiForecastAdapter.java
@@ -107,9 +107,17 @@ public class AiForecastAdapter {
 
             // 2. "data" 키에 해당하는 자식 노드만 추출
             JsonNode dataNode = rootNode.get("data");
-
+        //=====================성공===============================
             if (dataNode != null && !dataNode.isNull()) {
-                return objectMapper.treeToValue(dataNode, AiForecastResponse.class);
+                AiForecastResponse res = objectMapper.treeToValue(dataNode, AiForecastResponse.class);
+                boolean allEmpty = (res.summary() == null)
+                        && (res.chartForecast() == null || res.chartForecast().isEmpty())
+                        && (res.chartPortfolio() == null || res.chartPortfolio().isEmpty())
+                        && (res.recommendations() == null || res.recommendations().isEmpty());
+                if (allEmpty) {
+                    throw new BusinessException("AI가 유의미한 분석을 반환하지 않았습니다. 입력 조건을 확인하거나 잠시 후 다시 시도해주세요.");
+                }
+                return res; //<- 성공한 결과
             }
         } catch (Exception e) {
             log.error("JSON 매핑 실패: {}", e.getMessage());

--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -149,7 +149,8 @@ public class ForecastApplication {
                 new AiForecastRequestToAi.Conditions(
                         c.year(),
                         // a) ToAi.semester 타입이 Integer인 현재 파일 기준
-                        aiSemester,
+                        //aiSemester,
+                        c.semester(),
                         c.campus(),          // org_cd
                         c.department(),      // dept_cd
                         c.category(),

--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.usto.api.ai.common.AiForecastAdapter;
 import com.usto.api.ai.forecast.domain.model.Forecast;
+import com.usto.api.ai.forecast.domain.model.RiskLevel;
 import com.usto.api.ai.forecast.domain.repository.ForecastRepository;
 import com.usto.api.ai.forecast.domain.service.ForecastPolicy;
 import com.usto.api.ai.forecast.infrastructure.mapper.ForecastMapper;
@@ -16,6 +17,7 @@ import com.usto.api.common.exception.BusinessException;
 import com.usto.api.organization.infrastructure.entity.DepartmentJpaEntity;
 import com.usto.api.organization.infrastructure.repository.DepartmentJpaRepository;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -141,8 +143,8 @@ public class ForecastApplication {
         AiForecastRequest.Conditions c = request.conditions();
 
         String aiSemester = toAiSemester(c.semester());
-
         String deptName = resolveDeptName(c.campus(),c.department());
+        RiskLevel riskLevel = toAiRiskLevel(c.risk_level());
 
         return new AiForecastRequestToAi(
                 request.prompt(),
@@ -152,9 +154,18 @@ public class ForecastApplication {
                         c.campus(),          //7008277
                         deptName,             //소프트웨어융합대학행정실
                         c.category(),
-                        c.risk_level()      //Low, Midium, High
+                        riskLevel      //Low, Medium, High
                 )
         );
+    }
+
+    private RiskLevel toAiRiskLevel(RiskLevel riskLevel) {
+        // AI 팀 스펙 확정에 맞춰 문자열 enum으로 변환
+        return switch (riskLevel) {
+            case LOW -> RiskLevel.LOW;
+            case MEDIUM -> RiskLevel.MEDIUM;
+            case HIGH -> RiskLevel.HIGH;
+        };
     }
 
     private String toAiSemester(Integer sem) {

--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -148,11 +148,11 @@ public class ForecastApplication {
                 request.prompt(),
                 new AiForecastRequestToAi.Conditions(
                         c.year(), //2026
-                        aiSemester, //SPRING, SUMMER, FALL, WINTER
+                        aiSemester, //1, 여름, 2, 겨울
                         c.campus(),          //7008277
                         deptName,             //소프트웨어융합대학행정실
                         c.category(),
-                        c.risk_level()      //LOW, MID, HIGH (UI에서 선택된 값이 그대로 넘어옴)
+                        c.risk_level()      //Low, Midium, High
                 )
         );
     }
@@ -160,10 +160,10 @@ public class ForecastApplication {
     private String toAiSemester(Integer sem) {
         // AI 팀 스펙 확정에 맞춰 문자열 enum으로 변환
         return switch (sem) {
-            case 1 -> "SPRING";
-            case 2 -> "SUMMER";
-            case 3 -> "FALL";
-            case 4 -> "WINTER";
+            case 1 -> "1";
+            case 2 -> "여름";
+            case 3 -> "2";
+            case 4 -> "겨울";
             default -> throw new IllegalArgumentException("semester은 1-4값이여야합니다.: " + sem);
         };
     }

--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -147,15 +147,12 @@ public class ForecastApplication {
         return new AiForecastRequestToAi(
                 request.prompt(),
                 new AiForecastRequestToAi.Conditions(
-                        c.year(),
-                        // a) ToAi.semester 타입이 Integer인 현재 파일 기준
-                        //aiSemester,
-                        c.semester(),
-                        c.campus(),          // org_cd
-                        c.department(),      // dept_cd
+                        c.year(), //2026
+                        aiSemester, //SPRING, SUMMER, FALL, WINTER
+                        c.campus(),          //7008277
+                        deptName,             //소프트웨어융합대학행정실
                         c.category(),
-                        c.risk_level(),      // enum은 문자열로 직렬화되어 전송됨
-                        deptName             // dept_name
+                        c.risk_level()      //LOW, MID, HIGH (UI에서 선택된 값이 그대로 넘어옴)
                 )
         );
     }

--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -10,8 +10,11 @@ import com.usto.api.ai.forecast.domain.repository.ForecastRepository;
 import com.usto.api.ai.forecast.domain.service.ForecastPolicy;
 import com.usto.api.ai.forecast.infrastructure.mapper.ForecastMapper;
 import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequest;
+import com.usto.api.ai.forecast.presentation.dto.request.AiForecastRequestToAi;
 import com.usto.api.ai.forecast.presentation.dto.response.AiForecastResponse;
 import com.usto.api.common.exception.BusinessException;
+import com.usto.api.organization.infrastructure.entity.DepartmentJpaEntity;
+import com.usto.api.organization.infrastructure.repository.DepartmentJpaRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +33,7 @@ public class ForecastApplication {
     private final ObjectMapper objectMapper;
     private final ForecastPolicy forecastPolicy;
     private final ForecastRepository forecastRepository;
+    private final DepartmentJpaRepository departmentJpaRepository;
 
     @Transactional
     public AiForecastResponse analyze(String usrId, String orgCd, AiForecastRequest request) {
@@ -38,8 +42,10 @@ public class ForecastApplication {
         forecastPolicy.validateRequest(request,orgCd);
         forecastPolicy.validateOrganization(request.conditions().campus(),orgCd);
 
+        AiForecastRequestToAi requestToAi = toAiPayload(request);
+
         // AI 호출
-        AiForecastResponse aiResponse = aiForecastAdapter.fetchForecastResponse(request);
+        AiForecastResponse aiResponse = aiForecastAdapter.fetchForecastResponse(requestToAi);
 
         log.info("AI Response: {}", aiResponse);
         log.info("summary : {}",aiResponse.summary());
@@ -49,7 +55,7 @@ public class ForecastApplication {
                 usrId,
                 request.conditions().year().shortValue(),
                 request.conditions().semester().byteValue(),
-                request.conditions().riskLevel(),
+                request.conditions().risk_level(),
                 request.prompt(),
                 orgCd,
                 toJsonNullable(aiResponse.summary()),
@@ -129,5 +135,48 @@ public class ForecastApplication {
 
         forecastRepository.delete(forecastId);
 
+    }
+
+    private AiForecastRequestToAi toAiPayload(AiForecastRequest request) {
+        AiForecastRequest.Conditions c = request.conditions();
+
+        String aiSemester = toAiSemester(c.semester());
+
+        String deptName = resolveDeptName(c.campus(),c.department());
+
+        return new AiForecastRequestToAi(
+                request.prompt(),
+                new AiForecastRequestToAi.Conditions(
+                        c.year(),
+                        // a) ToAi.semester 타입이 Integer인 현재 파일 기준
+                        aiSemester,
+                        c.campus(),          // org_cd
+                        c.department(),      // dept_cd
+                        c.category(),
+                        c.risk_level(),      // enum은 문자열로 직렬화되어 전송됨
+                        deptName             // dept_name
+                )
+        );
+    }
+
+    private String toAiSemester(Integer sem) {
+        // AI 팀 스펙 확정에 맞춰 문자열 enum으로 변환
+        return switch (sem) {
+            case 1 -> "SPRING";
+            case 2 -> "SUMMER";
+            case 3 -> "FALL";
+            case 4 -> "WINTER";
+            default -> throw new IllegalArgumentException("semester은 1-4값이여야합니다.: " + sem);
+        };
+    }
+
+    private String resolveDeptName(String campus,String department) {
+
+        return departmentJpaRepository.findById_OrgCdAndId_DeptCd(campus, department)
+                .map(DepartmentJpaEntity::getDeptNm)
+                .orElseGet(() -> {
+                    log.warn("학과명 조회 실패: campus={}, dept_cd={}", campus, department);
+                    return department;
+                });
     }
 }

--- a/src/main/java/com/usto/api/ai/forecast/domain/model/RiskLevel.java
+++ b/src/main/java/com/usto/api/ai/forecast/domain/model/RiskLevel.java
@@ -1,7 +1,8 @@
 package com.usto.api.ai.forecast.domain.model;
 
 public enum RiskLevel {
-    High,
-    Medium,
-    Low
+    HIGH,
+    MEDIUM,
+    LOW
+
 }

--- a/src/main/java/com/usto/api/ai/forecast/domain/model/RiskLevel.java
+++ b/src/main/java/com/usto/api/ai/forecast/domain/model/RiskLevel.java
@@ -1,7 +1,7 @@
 package com.usto.api.ai.forecast.domain.model;
 
 public enum RiskLevel {
-    LOW,
-    MID,
-    HIGH
+    High,
+    Medium,
+    Low
 }

--- a/src/main/java/com/usto/api/ai/forecast/domain/service/ForecastPolicy.java
+++ b/src/main/java/com/usto/api/ai/forecast/domain/service/ForecastPolicy.java
@@ -65,7 +65,7 @@ public class ForecastPolicy {
         }
 
         // risk_level (enum)
-        if (c.riskLevel() == null) {
+        if (c.risk_level() == null) {
             throw new BusinessException("conditions.risk_level은 필수입니다.");
         }
     }

--- a/src/main/java/com/usto/api/ai/forecast/domain/service/ForecastPolicy.java
+++ b/src/main/java/com/usto/api/ai/forecast/domain/service/ForecastPolicy.java
@@ -34,8 +34,8 @@ public class ForecastPolicy {
         if (c.semester() == null) {
             throw new BusinessException("conditions.semester는 필수입니다.");
         }
-        if (c.semester() != 1 && c.semester() != 2) {
-            throw new BusinessException("conditions.semester는 1 또는 2만 허용됩니다.");
+        if (c.semester() < 1 || c.semester() > 4) {
+            throw new BusinessException("conditions.semester는 1,2,3,4만 허용됩니다.");
         }
 
         // campus/org

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
@@ -35,7 +35,7 @@ public record AiForecastRequest(
             @Schema(example = "")
             String category,          // 물품분류명 (입력 안 하면 null 또는 빈 값)
 
-            @Schema(example = "Low")
+            @Schema(example = "LOW")
             @NotNull RiskLevel risk_level //리스크 성향 (UI의 Low/Mid/High 선택값)
     ) {}
 }

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
@@ -20,7 +20,7 @@ public record AiForecastRequest(
             @NotNull Integer year, //년도 (예: 2026)
 
             @Schema(example = "1")
-            @NotNull Integer semester, //1또는2
+            @NotNull Integer semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
             @JsonProperty("org_cd")
             @JsonAlias({"campus"})

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequest.java
@@ -35,7 +35,7 @@ public record AiForecastRequest(
             @Schema(example = "")
             String category,          // 물품분류명 (입력 안 하면 null 또는 빈 값)
 
-            @Schema(example = "LOW")
+            @Schema(example = "Low")
             @NotNull RiskLevel risk_level //리스크 성향 (UI의 Low/Mid/High 선택값)
     ) {}
 }

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
@@ -20,7 +20,7 @@ public record AiForecastRequestToAi(
             @NotNull Integer year, //년도 (예: 2026)
 
             @Schema(example = "1")
-            @NotNull String semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
+            @NotNull Integer semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
             @JsonProperty("org_cd")
             @JsonAlias({"campus"})

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record AiForecastRequest(
+public record AiForecastRequestToAi(
 
         @Schema(example = "분석해줘")
         @NotBlank String prompt,
@@ -20,7 +20,7 @@ public record AiForecastRequest(
             @NotNull Integer year, //년도 (예: 2026)
 
             @Schema(example = "1")
-            @NotNull Integer semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
+            @NotNull String semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
             @JsonProperty("org_cd")
             @JsonAlias({"campus"})
@@ -36,6 +36,9 @@ public record AiForecastRequest(
             String category,          // 물품분류명 (입력 안 하면 null 또는 빈 값)
 
             @Schema(example = "LOW")
-            @NotNull RiskLevel risk_level //리스크 성향 (UI의 Low/Mid/High 선택값)
+            @NotNull RiskLevel risk_level, //리스크 성향 (UI의 Low/Mid/High 선택값)
+
+            @JsonProperty("dept_name")
+            String dept_name
     ) {}
 }

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
@@ -20,25 +20,20 @@ public record AiForecastRequestToAi(
             @NotNull Integer year, //년도 (예: 2026)
 
             @Schema(example = "1")
-            @NotNull Integer semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
+            @NotNull String semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
-            @JsonProperty("org_cd")
-            @JsonAlias({"campus"})
             @Schema(example = "7008277")
             @NotBlank String campus, //org_cd
 
-            @JsonProperty("dept_cd")
+            @JsonProperty("dept_name")
             @JsonAlias({"department"})
             @Schema(example = "A012")
-            @NotBlank String department, //dept_cd
+            String dept_name, //dept_cd
 
             @Schema(example = "")
             String category,          // 물품분류명 (입력 안 하면 null 또는 빈 값)
 
             @Schema(example = "LOW")
-            @NotNull RiskLevel risk_level, //리스크 성향 (UI의 Low/Mid/High 선택값)
-
-            @JsonProperty("dept_name")
-            String dept_name
+            @NotNull RiskLevel risk_level //리스크 성향 (UI의 Low/Mid/High 선택값)
     ) {}
 }

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
@@ -22,18 +22,19 @@ public record AiForecastRequestToAi(
             @Schema(example = "1")
             @NotNull String semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
+            @JsonProperty("org_cd")
             @Schema(example = "7008277")
             @NotBlank String campus, //org_cd
 
             @JsonProperty("dept_name")
             @JsonAlias({"department"})
-            @Schema(example = "A012")
-            String dept_name, //dept_cd
+            String deptName, //소프트웨어융합대학행정실
 
             @Schema(example = "")
             String category,          // 물품분류명 (입력 안 하면 null 또는 빈 값)
 
-            @Schema(example = "LOW")
-            @NotNull RiskLevel risk_level //리스크 성향 (UI의 Low/Mid/High 선택값)
+            @JsonProperty("risk_level")
+            @Schema(example = "Low")
+            @NotNull RiskLevel riskLevel //리스크 성향 (UI의 Low/Medium/High 선택값)
     ) {}
 }

--- a/src/main/java/com/usto/api/organization/domain/model/Department.java
+++ b/src/main/java/com/usto/api/organization/domain/model/Department.java
@@ -1,0 +1,4 @@
+package com.usto.api.organization.domain.model;
+
+public class Department {
+}

--- a/src/main/java/com/usto/api/organization/domain/model/Organization.java
+++ b/src/main/java/com/usto/api/organization/domain/model/Organization.java
@@ -1,0 +1,4 @@
+package com.usto.api.organization.domain.model;
+
+public class Organization {
+}

--- a/src/main/java/com/usto/api/organization/infrastructure/Adapter.java
+++ b/src/main/java/com/usto/api/organization/infrastructure/Adapter.java
@@ -1,4 +1,0 @@
-package com.usto.api.organization.infrastructure;
-
-public class Adapter {
-}

--- a/src/main/java/com/usto/api/organization/infrastructure/Adapter.java
+++ b/src/main/java/com/usto/api/organization/infrastructure/Adapter.java
@@ -1,0 +1,4 @@
+package com.usto.api.organization.infrastructure;
+
+public class Adapter {
+}

--- a/src/main/java/com/usto/api/organization/infrastructure/repository/DepartmentJpaRepository.java
+++ b/src/main/java/com/usto/api/organization/infrastructure/repository/DepartmentJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DepartmentJpaRepository extends JpaRepository<DepartmentJpaEntity, DeptId> {
@@ -14,4 +15,6 @@ public interface DepartmentJpaRepository extends JpaRepository<DepartmentJpaEnti
 
     // 운용부서 존재 여부 확인
     boolean existsById_OrgCdAndId_DeptCd(String orgCd, String deptCd);
+
+    Optional<DepartmentJpaEntity> findById_OrgCdAndId_DeptCd(String orgCd, String deptCd);
 }

--- a/src/main/java/com/usto/api/user/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/usto/api/user/presentation/dto/request/LoginRequest.java
@@ -12,6 +12,6 @@ public class LoginRequest {
     private String usrId;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Schema(example = "1234qwe!")
+    @Schema(example = "Qwer1234!")
     private String pwd;
 }


### PR DESCRIPTION
✨ 변경 사항 설명

 [전송용 DTO 분리]
AiForecastRequestToAi 신설
내부 DTO를 그대로 보내지 않고, AI 스펙 전용 DTO로 변환 후 전송

[필드 스키마 맞춤]
semester: int → AI가 요구하는 String으로 변환
1 → "1"
2 → "여름"
3 → "2"
4 → "겨울"
dept_name: DB 조회로 학과명 채움
risk_level: enum 값은 유지하되 키 이름은 snake_case로 전달

 [매핑 로직 분리]
ForecastApplication.toAiPayload(...) 추가
내부 요청 AiForecastRequest를 AI 전송용 DTO로 변환

[학과명 조회 보완]
DepartmentJpaRepository.findById_OrgCdAndId_DeptCd(...) 추가
조직코드 + 학과코드로 학과명 조회
조회 실패 시 경고 로그 후 dept_cd를 fallback으로 사용

[AI 응답 검증 강화]
4xx/5xx 응답 시 상세 로그 + 원문 바디 로깅
응답 data 안의
summary
chart_forecast
chart_portfolio
recommendations
가 전부 비어 있으면 BusinessException 발생

[요청 검증 유지/강화]
semester는 1~4 범위 검증
요청 campus(org)와 로그인 orgCd 일치 여부 검증

[최종 흐름]
입력 DTO 수신
정책 검증
AI 전송용 DTO 변환
AI 호출
응답 검증 후 저장

🔔 Pull Request 유형

[x] 버그 수정
[x] 코드 리팩토링
[x] 주석 추가 / 수정
[ ] 새로운 기능 추가
[ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
[ ] 문서 수정
[ ] 테스트 코드 추가 / 수정
[ ] 빌드 설정 또는 패키지 매니저 수정
[ ] 파일 또는 폴더 이름 변경
[ ] 파일 또는 폴더 삭제