### PR TITLE
Fix: #155 add username item history

### DIFF
--- a/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
@@ -23,6 +23,7 @@ import com.usto.api.item.asset.presentation.dto.response.*;
 import com.usto.api.item.common.model.OperStatus;
 import com.usto.api.organization.infrastructure.entity.QDepartmentJpaEntity;
 import com.usto.api.organization.infrastructure.entity.QOrganizationJpaEntity;
+import com.usto.api.user.infrastructure.entity.QUserJpaEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -37,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.usto.api.item.acquisition.infrastructure.entity.QItemAcquisitionEntity.itemAcquisitionEntity;
 import static com.usto.api.item.asset.infrastructure.entity.QItemAssetEntity.itemAssetEntity;
@@ -219,22 +219,33 @@ public class AssetRepositoryAdapter implements AssetRepository {
 
     @Override
     public List<AssetDetailResponse.StatusHistoryDto> findStatusHistoriesByItmNo(String itmNo, String orgCd) {
-        List<ItemAssetStatusHistoryEntity> entities =
-                statusHistoryJpaRepository.findByItmNoAndOrgCdOrderByApprAtDesc(itmNo, orgCd);
+        QItemAssetStatusHistoryEntity history = QItemAssetStatusHistoryEntity.itemAssetStatusHistoryEntity;
+        QUserJpaEntity reqUser = new QUserJpaEntity("reqUser");
+        QUserJpaEntity apprUser = new QUserJpaEntity("apprUser");
 
-        return entities.stream()
-                .map(entity -> AssetDetailResponse.StatusHistoryDto.builder()
-                        .itemHisId(entity.getItemHisId().toString())
-                        .itmNo(entity.getItmNo())
-                        .prevSts(entity.getPrevSts() != null ? entity.getPrevSts() : null)
-                        .newSts(entity.getNewSts())
-                        .chgRsn(entity.getChgRsn())
-                        .reqUsrId(entity.getReqUsrId())
-                        .reqAt(entity.getReqAt())
-                        .apprUsrId(entity.getApprUsrId())
-                        .apprAt(entity.getApprAt())
-                        .build())
-                .collect(Collectors.toList());
+        return queryFactory
+                .select(Projections.fields(AssetDetailResponse.StatusHistoryDto.class,
+                        history.itemHisId,
+                        history.itmNo,
+                        history.prevSts,
+                        history.newSts,
+                        history.chgRsn,
+                        history.reqUsrId,
+                        reqUser.usrNm.as("reqUsrNm"),
+                        history.reqAt,
+                        history.apprUsrId,
+                        apprUser.usrNm.as("apprUsrNm"),
+                        history.apprAt
+                ))
+                .from(history)
+                .leftJoin(reqUser).on(history.reqUsrId.eq(reqUser.usrId))
+                .leftJoin(apprUser).on(history.apprUsrId.eq(apprUser.usrId))
+                .where(
+                        history.itmNo.eq(itmNo),
+                        history.orgCd.eq(orgCd)
+                )
+                .orderBy(history.apprAt.desc())
+                .fetch();
     }
 
     /**

--- a/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
@@ -242,7 +242,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                 .leftJoin(apprUser).on(history.apprUsrId.eq(apprUser.usrId))
                 .where(
                         history.itmNo.eq(itmNo),
-                        history.orgCd.eq(orgCd)
+                        history.orgCd.eq(orgCd),
+                        history.delYn.eq("N")
                 )
                 .orderBy(history.apprAt.desc())
                 .fetch();

--- a/src/main/java/com/usto/api/item/asset/infrastructure/entity/ItemAssetStatusHistoryEntity.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/entity/ItemAssetStatusHistoryEntity.java
@@ -31,11 +31,9 @@ public class ItemAssetStatusHistoryEntity extends BaseTimeEntity {
     @Column(name = "ITM_NO", nullable = false, length = 10, columnDefinition = "char(10)")
     private String itmNo;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "PREV_STS", length = 30)
     private OperStatus prevSts;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "NEW_STS", nullable = false, length = 30)
     private OperStatus newSts;
 

--- a/src/main/java/com/usto/api/item/asset/presentation/dto/response/AssetDetailResponse.java
+++ b/src/main/java/com/usto/api/item/asset/presentation/dto/response/AssetDetailResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Builder
@@ -72,7 +73,7 @@ public class AssetDetailResponse {
     public static class StatusHistoryDto {
 
         @Schema(description = "상태이력ID")
-        private String itemHisId;
+        private UUID itemHisId;
 
         @Schema(description = "물품고유번호")
         private String itmNo;
@@ -89,12 +90,18 @@ public class AssetDetailResponse {
         @Schema(description = "등록자ID")
         private String reqUsrId;
 
+        @Schema(description = "등록자명")
+        private String reqUsrNm;
+
         @Schema(description = "등록일자")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         private LocalDate reqAt;
 
         @Schema(description = "확정자ID")
         private String apprUsrId;
+
+        @Schema(description = "확정자명")
+        private String apprUsrNm;
 
         @Schema(description = "확정일자(변경일자)")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/com/usto/api/item/common/converter/OperStatusConverter.java
+++ b/src/main/java/com/usto/api/item/common/converter/OperStatusConverter.java
@@ -1,0 +1,25 @@
+package com.usto.api.item.common.converter;
+
+import com.usto.api.item.common.model.OperStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+
+@Converter(autoApply = true)
+public class OperStatusConverter implements AttributeConverter<OperStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(OperStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public OperStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) return null;
+        try {
+            return OperStatus.valueOf(dbData);
+        } catch (IllegalArgumentException e) {
+            return null;  // NONE 등 알 수 없는 값 → null 처리
+        }
+    }
+}

--- a/src/main/resources/db/seed/user/insert_dummy_data_user.sql
+++ b/src/main/resources/db/seed/user/insert_dummy_data_user.sql
@@ -1,0 +1,45 @@
+USE usto;
+
+INSERT INTO TB_USER001M (
+    USR_ID, USR_NM, PW_HASH, EMAIL, SMS, ROLE_ID, APPR_STS, APPR_USR_ID, APPR_AT,
+    ORG_CD, DEL_YN, DEL_AT, CRE_BY, CRE_AT, UPD_BY, UPD_AT
+) VALUES (
+             'hyl0610',
+             '황팀장',
+             '$2a$10$QmFxeeEtHZICHdP0cuAciuOE.JLca/BQxCqKc0a8m265Sf524IHO6',
+             'admin1@hanyang.ac.kr',
+             '01000000000',
+             'ADMIN',
+             'APPROVED',
+             NULL,
+             NULL,
+             '7008277',
+             'N',
+             NULL,
+             'system',
+             NOW(),
+             NULL,
+             NULL
+         );
+
+INSERT INTO TB_USER001M (
+    USR_ID, USR_NM, PW_HASH, EMAIL, SMS, ROLE_ID, APPR_STS, APPR_USR_ID, APPR_AT,
+    ORG_CD, DEL_YN, DEL_AT, CRE_BY, CRE_AT, UPD_BY, UPD_AT
+) VALUES (
+             'badbergjr',
+             '박대리',
+             '$2a$10$nt1NkwIvjiybvwx3TXwWo.T7ni0siaTI2KgVa7/nCt1EdHSHOrmRK',
+             'manager1@hanyang.ac.kr',
+             '01000000001',
+             'MANAGER',
+             'APPROVED',
+             NULL,
+             NULL,
+             '7008277',
+             'N',
+             NULL,
+             'system',
+             NOW(),
+             NULL,
+             NULL
+         );


### PR DESCRIPTION
### ✨ 변경 사항 설명

- 물품상태이력 응답에 등록자/관리자명 추가
  - 물품상세조회 response에 필드 추가
  - AssetRepositoryAdapter의 물품상태이력 조회 메서드 쿼리 수정
 - 운용상태(OperStatus) 컨버터 추가
   - 기존 물품상태이력 응답에서 prevSts 또는 newSts의 값이 운용상태 enum에 없는 값(NONE, ACQ)일때 응답에 오류가 나고 있었음
   - enum에 없는 값이면 프론트에 null로 전달하도록 컨버터 추가해서 고침

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [ ] 테스트 코드 추가 / 수정
- [x] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제
