### PR TITLE
Bug: #157 처분 물품이 이력 내역에 안보이는 버그 수정

### DIFF
--- a/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetRepositoryAdapter.java
@@ -122,7 +122,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                         arrgAtBetween(cond.getStartArrgAt(), cond.getEndArrgAt()),
                         deptCdEq(cond.getDeptCd()),
                         operStsEq(cond.getOperSts()),
-                        itmNoEq(cond.getItmNo())
+                        itmNoEq(cond.getItmNo()),
+                        itemAssetEntity.delYn.eq("N")
                 )
                 .fetchOne();
 
@@ -161,7 +162,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                         arrgAtBetween(cond.getStartArrgAt(), cond.getEndArrgAt()),
                         deptCdEq(cond.getDeptCd()),
                         operStsEq(cond.getOperSts()),
-                        itmNoEq(cond.getItmNo())
+                        itmNoEq(cond.getItmNo()),
+                        itemAssetEntity.delYn.eq("N")
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -203,7 +205,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                 )
                 .where(
                         itemAssetEntity.itemId.itmNo.eq(itmNo),
-                        itemAssetEntity.itemId.orgCd.eq(orgCd)
+                        itemAssetEntity.itemId.orgCd.eq(orgCd),
+                        itemAssetEntity.delYn.eq("N")
                 )
                 .fetchOne();
 
@@ -390,7 +393,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                         deptCdEq(searchRequest.getDeptCd()),
                         operStsEq(searchRequest.getOperSts()),
                         itmNoEq(searchRequest.getItmNo()),
-                        printYnEq(searchRequest.getPrintYn())
+                        printYnEq(searchRequest.getPrintYn()),
+                        itemAssetEntity.delYn.eq("N")
                 )
                 .fetchOne();
 
@@ -431,7 +435,8 @@ public class AssetRepositoryAdapter implements AssetRepository {
                         deptCdEq(searchRequest.getDeptCd()),
                         operStsEq(searchRequest.getOperSts()),
                         itmNoEq(searchRequest.getItmNo()),
-                        printYnEq(searchRequest.getPrintYn())
+                        printYnEq(searchRequest.getPrintYn()),
+                        itemAssetEntity.delYn.eq("N")
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/usto/api/item/asset/infrastructure/entity/ItemAssetEntity.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/entity/ItemAssetEntity.java
@@ -5,7 +5,6 @@ import com.usto.api.item.common.model.OperStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -21,7 +20,6 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @SQLDelete(sql = "UPDATE TB_ITEM002 SET del_yn = 'Y', del_at = NOW() WHERE itm_no = ? AND org_cd = ?")
-@Where(clause = "DEL_YN = 'N'")
 public class ItemAssetEntity extends BaseTimeEntity {
 
     @EmbeddedId


### PR DESCRIPTION
### ✨ 변경 사항 설명

- ItemAssetEntity에 있던 어노테이션 @Where(clause = "DEL_YN = 'N'") 삭제
  - 기본적으로 소프트삭제된 데이터가 조회되지 않도록 해주는 어노테이션
- 운용대장/보유현황 조회 쿼리에 명시적으로 itemAssetEntity.delYn.eq("N") 조건을 추가

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [ ] 테스트 코드 추가 / 수정
- [ ] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제

---

### 📷 스크린샷 (선택)
이전에 안보이던 반납등록의 상세물품목록이 정상적으로 조회되는 것 확인
<img width="511" height="304" alt="image" src="https://github.com/user-attachments/assets/5dd25b81-26c3-472d-9ea4-99e02b97a4f2" />


