### PR TITLE
Bug: #164 취득/운용전환/반납/불용/처분 반려 시 승인일자 기입하는 코드 삭제

### DIFF
--- a/src/main/java/com/usto/api/item/acquisition/domain/model/Acquisition.java
+++ b/src/main/java/com/usto/api/item/acquisition/domain/model/Acquisition.java
@@ -1,6 +1,5 @@
 package com.usto.api.item.acquisition.domain.model;
 
-import com.usto.api.common.exception.BusinessException;
 import com.usto.api.item.common.model.ApprStatus;
 import com.usto.api.item.common.model.OperStatus;
 import lombok.Builder;
@@ -107,6 +106,5 @@ public class Acquisition {
     public void rejectApproval(String userId) {
         this.apprUsrId = userId;
         this.apprSts = ApprStatus.REJECTED;
-        this.apprAt = LocalDate.now(KOREA_ZONE);
     }
 }

--- a/src/main/java/com/usto/api/item/disposal/domain/model/DisposalMaster.java
+++ b/src/main/java/com/usto/api/item/disposal/domain/model/DisposalMaster.java
@@ -54,14 +54,13 @@ public class DisposalMaster {
 
     //승인
     public void confirmApproval(String userId) {
-        this.apprSts = ApprStatus.APPROVED; //불용 확정 처라
+        this.apprSts = ApprStatus.APPROVED; //처분 확정 처라
         this.apprUsrId = userId;
         this.dispApprAt = LocalDate.now();
     }
     //반려
     public void rejectApproval(String userId) {
-        this.apprSts = ApprStatus.REJECTED; //불용 반려 처라
+        this.apprSts = ApprStatus.REJECTED; //처분 반려 처라
         this.apprUsrId = userId;
-        this.dispApprAt = LocalDate.now();
     }
 }

--- a/src/main/java/com/usto/api/item/disuse/domain/model/DisuseMaster.java
+++ b/src/main/java/com/usto/api/item/disuse/domain/model/DisuseMaster.java
@@ -63,6 +63,5 @@ public class DisuseMaster {
     public void rejectApproval(String userId) {
         this.apprSts = ApprStatus.REJECTED; //불용 반려 처라
         this.apprUsrId = userId;
-        this.dsuApprAt = LocalDate.now();
     }
 }

--- a/src/main/java/com/usto/api/item/operation/domain/model/OperationMaster.java
+++ b/src/main/java/com/usto/api/item/operation/domain/model/OperationMaster.java
@@ -69,6 +69,5 @@ public class OperationMaster {
     public void rejectApproval(String userId) {
         this.apprUsrId = userId;
         this.apprSts = ApprStatus.REJECTED;
-        this.operApprAt = LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/usto/api/item/returning/domain/model/ReturningMaster.java
+++ b/src/main/java/com/usto/api/item/returning/domain/model/ReturningMaster.java
@@ -65,6 +65,5 @@ public class ReturningMaster {
     public void rejectApproval(String userId) {
         this.apprSts = ApprStatus.REJECTED; //반납 반려 처라
         this.apprUsrId = userId;
-        this.rtrnApprAt = LocalDate.now();
     }
 }


### PR DESCRIPTION
### ✨ 변경 사항 설명

- 취득/운용전환/반납/불용/처분 반려시 apprAt 을 기입하는 코드 삭제함
- 서버 DB에서 반려된 데이터 중 승인일자 있는것들은 승인일자 삭제함

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [ ] 테스트 코드 추가 / 수정
- [ ] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제

---

### 🗒️ 참고 사항 (선택)

- 반려 시 승인일자(appr_at)는 기입안하는게 맞는데, appr_usr_id는 기입하고있음 (반려한 관리자의 아이디로)
- 반려한 사람이 누군지를 기록하려면 기입하는게 맞는 것 같은데, 컬럼의 이름이 승인자라는 의미를 가지고 있어서 약간 찝찝함
- 일단 화면상에서 반려 데이터에 대해 '승인자'라고 나오는 부분은 없기때문에 그냥 두겟음