### PR TITLE
Bug: #162 취득/반납/불용/처분 승인 확정 시 이력의 변경상태 오류

### DIFF
--- a/src/main/java/com/usto/api/item/asset/application/AssetApplication.java
+++ b/src/main/java/com/usto/api/item/asset/application/AssetApplication.java
@@ -2,9 +2,11 @@ package com.usto.api.item.asset.application;
 
 import com.usto.api.item.acquisition.domain.model.Acquisition;
 import com.usto.api.item.asset.domain.model.Asset;
+import com.usto.api.item.asset.domain.model.AssetStatusHistory;
 import com.usto.api.item.asset.domain.model.QrLabelData;
 import com.usto.api.item.asset.domain.repository.AssetInventoryStatusRepository;
 import com.usto.api.item.asset.domain.repository.AssetRepository;
+import com.usto.api.item.asset.domain.repository.AssetStatusHistoryRepository;
 import com.usto.api.item.asset.domain.service.AssetPolicy;
 import com.usto.api.item.asset.infrastructure.mapper.AssetMapper;
 import com.usto.api.item.asset.presentation.dto.request.AssetInventoryStatusSearchRequest;
@@ -27,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -44,6 +47,7 @@ public class AssetApplication {
     private final ItemNumberGenerator itemNumberGenerator;
     private final QrLabelPdfGenerator qrLabelPdfGenerator;
     private final OrganizationJpaRepository organizationJpaRepository;
+    private final AssetStatusHistoryRepository historyRepository;
 
     @Value("${app.frontend.base-url:http://13.124.10.41:8080}")  // 임시(프론트엔드 연동시 바꿔야함)
     private String frontendBaseUrl;
@@ -143,6 +147,23 @@ public class AssetApplication {
                     acq.getRmk()
             );
             assetRepository.save(asset); // 002D에 저장
+
+            // 이력 생성
+            AssetStatusHistory history = AssetStatusHistory.builder()
+                    .itemHisId(UUID.randomUUID())
+                    .itmNo(itmNo)
+                    .prevSts(null)            // 신규 등재라 이전 상태 없음
+                    .newSts(OperStatus.OPER)  // 하드코딩
+                    .chgRsn("신규 운용 등재")
+                    .reqUsrId(acq.getAplyUsrId())
+                    .reqAt(acq.getAcqAt())
+                    .apprUsrId(acq.getApprUsrId())
+                    .orgCd(acq.getOrgCd())
+                    .apprAt(LocalDate.now(ZoneId.of("Asia/Seoul")))
+                    .delYn("N")
+                    .build();
+
+            historyRepository.saveAll(List.of(history));
         }
     }
 

--- a/src/main/java/com/usto/api/item/asset/application/AssetApplication.java
+++ b/src/main/java/com/usto/api/item/asset/application/AssetApplication.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -130,6 +131,8 @@ public class AssetApplication {
         int currentYear = LocalDate.now().getYear();
         int nextSeq = assetRepository.getNextSequenceForYear(currentYear, acq.getOrgCd());
 
+        List<AssetStatusHistory> histories = new ArrayList<>();
+
         // 3. 취득수량만큼 반복문 수행
         for (int i = 0; i < acq.getAcqQty(); i++) {
             // 고유번호 생성 (예: M202600001, M202600002...)
@@ -149,7 +152,7 @@ public class AssetApplication {
             assetRepository.save(asset); // 002D에 저장
 
             // 이력 생성
-            AssetStatusHistory history = AssetStatusHistory.builder()
+            histories.add(AssetStatusHistory.builder()  // 루프 안에서 리스트에 추가
                     .itemHisId(UUID.randomUUID())
                     .itmNo(itmNo)
                     .prevSts(null)            // 신규 등재라 이전 상태 없음
@@ -161,10 +164,9 @@ public class AssetApplication {
                     .orgCd(acq.getOrgCd())
                     .apprAt(LocalDate.now(ZoneId.of("Asia/Seoul")))
                     .delYn("N")
-                    .build();
-
-            historyRepository.saveAll(List.of(history));
+                    .build());
         }
+        historyRepository.saveAll(histories);  // 루프 끝나고 한 번에 저장
     }
 
     /**

--- a/src/main/java/com/usto/api/item/common/converter/OperStatusConverter.java
+++ b/src/main/java/com/usto/api/item/common/converter/OperStatusConverter.java
@@ -19,7 +19,7 @@ public class OperStatusConverter implements AttributeConverter<OperStatus, Strin
         try {
             return OperStatus.valueOf(dbData);
         } catch (IllegalArgumentException e) {
-            return null;  // NONE 등 알 수 없는 값 → null 처리
+            return null;  // NONE, ACQ 등 운용상태 ENUM에 없는 알 수 없는 값 → null 처리
         }
     }
 }

--- a/src/main/java/com/usto/api/item/disposal/application/DisposalApplication.java
+++ b/src/main/java/com/usto/api/item/disposal/application/DisposalApplication.java
@@ -266,7 +266,7 @@ public class DisposalApplication {
                             .itemHisId(UUID.randomUUID())
                             .itmNo(itemNo)
                             .prevSts(prevStatus) //이전 상태
-                            .newSts(asset.getOperSts()) //현재 상태 = 반납
+                            .newSts(OperStatus.DISP) //변경 상태 = 처분
                             .chgRsn("처분 승인") //별도로 enum 관리를 하고싶다면 변동 가능성 있음.
                             .reqUsrId(master.getAplyUsrId())
                             .reqAt(master.getAplyAt())

--- a/src/main/java/com/usto/api/item/disposal/application/DisposalApplication.java
+++ b/src/main/java/com/usto/api/item/disposal/application/DisposalApplication.java
@@ -237,6 +237,7 @@ public class DisposalApplication {
      * - 승인 시 물품 소프트삭제
      * - 상태 이력 테이블에 기록
      */
+    @Transactional
     public void approvalDisposal(UUID dispMId, String userId, String orgCd) {
         DisposalMaster master = disposalRepository.findMasterById(dispMId, orgCd)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 불용 신청입니다."));
@@ -292,6 +293,7 @@ public class DisposalApplication {
     /**
      * 처분 반려 (ADMIN 권한)
      */
+    @Transactional
     public void rejectDisposal(UUID dispMId, String userId, String orgCd) {
         DisposalMaster master = disposalRepository.findMasterById(dispMId, orgCd)
                 .orElseThrow(() -> new BusinessException("존재하지 않는 불용 신청입니다."));

--- a/src/main/java/com/usto/api/item/disuse/application/DisuseApplication.java
+++ b/src/main/java/com/usto/api/item/disuse/application/DisuseApplication.java
@@ -241,7 +241,7 @@ public class DisuseApplication {
                     .itemHisId(UUID.randomUUID())
                     .itmNo(itemNo)
                     .prevSts(prevStatus) //이전 상태
-                    .newSts(asset.getOperSts()) //현재 상태 = 반납
+                    .newSts(OperStatus.DSU) //변경 상태 = 불용
                     .chgRsn(master.getDsuRsn().getDescription())
                     .reqUsrId(master.getAplyUsrId())
                     .reqAt(master.getAplyAt())

--- a/src/main/java/com/usto/api/item/returning/application/ReturningApplication.java
+++ b/src/main/java/com/usto/api/item/returning/application/ReturningApplication.java
@@ -242,7 +242,7 @@ public class ReturningApplication {
                     .itemHisId(UUID.randomUUID())
                     .itmNo(itemNo)
                     .prevSts(prevStatus) //이전 상태
-                    .newSts(asset.getOperSts()) //현재 상태 = 반납
+                    .newSts(OperStatus.RTN) //변경 상태 = 반납
                     .chgRsn(master.getRtrnRsn().getDescription())
                     .reqUsrId(master.getAplyUsrId())
                     .reqAt(master.getAplyAt())


### PR DESCRIPTION
### ✨ 변경 사항 설명

- 기존에는 newSts에다가 getOperSts 메서드로 현재 운용상태값을 받아와서 넣어줬음
   - 이때 운용상태가 최신으로 바뀌지 않은 상태에서 값을 받아오기 때문에 이력이 '반납' -> '반납' 이런식으로 생성된것으로 추측
- 받아오지 않고 도메인마다 newSts의 값을 직접 하드코딩함
- 취득 확정 시에는 상태이력이 아예 생성안되고 있었어서 이부분은 새로 추가함 (사유: '신규 운용 등재', 운용상태: 운용)

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [ ] 테스트 코드 추가 / 수정
- [ ] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제
