### PR TITLE
Bug: #176 asset inventory rmk null bug

### DIFF
--- a/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetInventoryStatusRepositoryAdapter.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/adapter/AssetInventoryStatusRepositoryAdapter.java
@@ -228,11 +228,9 @@ public class AssetInventoryStatusRepositoryAdapter implements AssetInventoryStat
 
     // NULL 안전 비교 헬퍼 메서드
     private BooleanExpression eqOrBothNull(StringPath field, String value) {
-        if (value == null) {
-            // value가 null이면 → "field IS NULL" 조건 생성
-            return field.isNull();
+        if (value == null || value.isEmpty()) {
+            return field.isNull().or(field.eq(""));
         }
-        // value가 null이 아니면 → "field = value" 조건 생성
         return field.eq(value);
     }
 

--- a/src/main/java/com/usto/api/item/asset/infrastructure/mapper/AssetMapper.java
+++ b/src/main/java/com/usto/api/item/asset/infrastructure/mapper/AssetMapper.java
@@ -73,7 +73,7 @@ public final class AssetMapper {
                 .operSts(domain.getOperSts())
                 .acqUpr(domain.getAcqUpr())
                 .drbYr(domain.getDrbYr())
-                .rmk(domain.getRmk())
+                .rmk(domain.getRmk() == null || domain.getRmk().isEmpty() ? null : domain.getRmk())
                 .printYn(domain.getPrintYn())
                 .delYn(domain.getDelYn())
                 .delAt(domain.getDelAt())


### PR DESCRIPTION
### ✨ 변경 사항 설명

- 상세조회 조건식 수정
   - 기존에는 rmk가 null인 경우 IS NULL 조건만 생성되어 DB에 빈문자열("")로 저장된 데이터 조회가 실패하는 문제 발생
   - NULL과 빈문자열을 동일하게 처리하도록 수정
- Entity 매핑 로직 수정
   - Asset 저장 시 빈문자열 remark 값이 그대로 DB에 저장되지 않도록 수정함
   - 빈문자열 입력 시 NULL로 저장되도록 정규화

---

### 🔔 Pull Request 유형  
이번 PR에서 해당되는 항목에 체크해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향 없는 변경 (오타 수정, 탭 간격, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 / 수정
- [ ] 문서 수정
- [ ] 테스트 코드 추가 / 수정
- [ ] 빌드 설정 또는 패키지 매니저 수정
- [ ] 파일 또는 폴더 이름 변경
- [ ] 파일 또는 폴더 삭제