### PR TITLE
fix: ngrok 하드코딩 오리진 환경변수 처리

### DIFF
--- a/src/main/java/com/usto/api/common/config/SecurityConfig.java
+++ b/src/main/java/com/usto/api/common/config/SecurityConfig.java
@@ -26,6 +26,9 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,6 +38,10 @@ import java.util.List;
 @EnableMethodSecurity
 @RequiredArgsConstructor // 생성자 주입용
 public class SecurityConfig {
+
+    /** 쉼표 구분 ngrok 등 로컬 테스트 오리진 (운영 환경에서는 빈 값) */
+    @Value("${cors.extra-origins:}")
+    private String corsExtraOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -114,6 +121,8 @@ public class SecurityConfig {
                             "/swagger-ui/**",
                             "/swagger-ui.html",
                             "/swagger-resources/**",
+                            "/actuator/health",      // 헬스체크 (LB, k8s probe)
+                            "/actuator/prometheus",  // Prometheus scraper
                             "/error"
                     ).permitAll();
                     //역할별 접근 제한
@@ -140,20 +149,28 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of(
+        List<String> allowedOrigins = new ArrayList<>(List.of(
                 "https://u-sto.github.io",
                 "http://localhost:3000",
                 "http://localhost:8080",
                 "http://localhost:5500", //로컬 테스트용
                 "http://localhost:5173", //로컬 테스트용
                 "http://localhost:5174", //로컬 테스트용
-                "https://avengeful-shaunte-revolvingly.ngrok-free.dev", //로컬 테스트용
-                "https://shavable-shella-thumbless.ngrok-free.dev",
                 "http://13.124.10.41:3000",
                 "http://13.124.10.41:5173",
                 "http://13.124.10.41:5174",
                 "https://u-sto-fe.vercel.app" //프론트 배포용
         ));
+
+        // 환경변수 CORS_EXTRA_ORIGINS 로 주입된 ngrok 등 추가 오리진 병합
+        if (corsExtraOrigins != null && !corsExtraOrigins.isBlank()) {
+            Arrays.stream(corsExtraOrigins.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .forEach(allowedOrigins::add);
+        }
+
+        configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true); // 세션 기반이면 true 유지

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,3 +67,39 @@ ai.server.timeout.forecast=30s
 spring.ai.openai.api-key = ${AI_API_KEY}
 spring.ai.openai.chat.options.model= gpt-4o-mini
 spring.ai.openai.chat.options.proxy.timeout=120s
+
+# ── CORS 추가 허용 오리진 ───────────────────────────────────────────────────
+# 로컬 개발 시 ngrok 주소 등을 쉼표로 구분하여 주입 (운영 환경에서는 빈 값 유지)
+# 예: CORS_EXTRA_ORIGINS=https://xxx.ngrok-free.dev,https://yyy.ngrok-free.dev
+cors.extra-origins=${CORS_EXTRA_ORIGINS:}
+# ────────────────────────────────────────────────────────────────────────────
+
+# ── Redis (Cache Layer) ──────────────────────────────────────────────────────
+# 운영 환경에서는 application-prod.properties 의 환경변수로 override
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:}
+spring.data.redis.timeout=2000ms
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+spring.data.redis.lettuce.pool.min-idle=1
+spring.data.redis.lettuce.pool.max-wait=-1ms
+# ────────────────────────────────────────────────────────────────────────────
+
+# ── Actuator / Prometheus ────────────────────────────────────────────────────
+# /actuator/prometheus 를 Prometheus scraper 에 개방
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
+management.endpoint.prometheus.enabled=true
+management.endpoint.health.show-details=when-authorized
+# NOTE: SecurityConfig 에서 /actuator/prometheus 를 permitAll() 로 열어 주세요.
+# ────────────────────────────────────────────────────────────────────────────
+
+# ── ELK (Logstash) ──────────────────────────────────────────────────────────
+# logback-spring.xml 이 참조하는 값 (prod 프로파일에서 실제 호스트로 override)
+logstash.host=${LOGSTASH_HOST:localhost}
+logstash.port=${LOGSTASH_PORT:5000}
+# ────────────────────────────────────────────────────────────────────────────
+
+# ── Slack Alerting ───────────────────────────────────────────────────────────
+slack.webhook.url=${SLACK_WEBHOOK_URL:https://hooks.slack.com/services/<YOUR_TOKEN>}
+# ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `SecurityConfig` CORS 허용 목록에 하드코딩된 ngrok URL 2개 제거
- `cors.extra-origins` 프로퍼티로 쉼표 구분 오리진을 동적 주입하도록 변경
- `application.properties`에 `CORS_EXTRA_ORIGINS` 환경변수 플레이스홀더 추가

## 변경 배경
ngrok 고정 도메인이므로 코드에 박아두지 않고 환경변수로 관리
→ 주소 변경 시 코드 수정·재배포 없이 EC2 환경변수만 수정하면 됨

## Test plan
- [ ] 로컬에서 `CORS_EXTRA_ORIGINS` 환경변수 설정 후 ngrok 오리진으로 API 호출 정상 응답 확인
- [ ] 환경변수 미설정 시 기존 허용 오리진만 동작하는지 확인