### PR TITLE
Fix: AI 분석 응답 필드 누락 수정 + 이전 분석 조회 상단 메타 추가

### DIFF
--- a/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
+++ b/src/main/java/com/usto/api/ai/forecast/application/ForecastApplication.java
@@ -94,6 +94,24 @@ public class ForecastApplication {
         JsonNode recoNode = readTreeOrNull(forecast.getRecoJson());
         JsonNode algoNode = readTreeOrNull(forecast.getSummaryJson());  //이렇게 안 하면 다 바꿔야함
 
+        // 조회 화면 상단 영역용 메타 복원 (저장된 조건 컬럼 + org/dept 코드를 표시값으로 변환)
+        Integer year = forecast.getAnalysisYear() == null ? null : forecast.getAnalysisYear().intValue();
+        String semesterLabel = toUiSemester(forecast.getSemester());
+        String campusName = resolveOrgName(forecast.getOrgCode());
+        String deptName = resolveDeptName(forecast.getOrgCode(), forecast.getDeptCd());
+        String riskDisplay = toUiRisk(forecast.getRiskLevel());
+        String category = forecast.getG2bDNm();
+        String period = (year == null ? "" : year + "년 ") + semesterLabel;
+
+        AiForecastResponse.ConditionsRaw conditions = new AiForecastResponse.ConditionsRaw(
+                year,
+                semesterLabel,
+                campusName,
+                deptName,
+                category,
+                forecast.getRiskLevel() == null ? null : forecast.getRiskLevel().name()
+        );
+
         // 저장을 섹션별로 했을 때, 다시 하나의 객체로 합쳐 반환
         AiForecastResponse aiForecastResponse = new AiForecastResponse(
                 tsNode == null ? null : objectMapper.convertValue(
@@ -107,7 +125,13 @@ public class ForecastApplication {
                 ),
                 algoNode == null ? null : objectMapper.convertValue(
                         algoNode, AiForecastResponse.AlgorithmGuideRaw.class
-                )
+                ),
+                forecast.getMessage(), //prompt
+                deptName,               //target = 운용부서명
+                riskDisplay,            //risk
+                period,                 //period
+                campusName,             //campus
+                conditions
         );
 
         return aiForecastResponse;
@@ -217,6 +241,28 @@ public class ForecastApplication {
             case MEDIUM -> RiskLevel.MEDIUM.getDisplayName();
             case HIGH -> RiskLevel.HIGH.getDisplayName();
              default -> throw new IllegalArgumentException("risk_level은 LOW, MEDIUM, HIGH값이여야합니다.: " + riskLevel);
+        };
+    }
+
+    // 조회 화면 표시용: 저장된 학기 코드(1~4) -> UI 라벨
+    private String toUiSemester(Byte sem) {
+        if (sem == null) return "";
+        return switch (sem.intValue()) {
+            case 1 -> "1학기";
+            case 2 -> "여름학기";
+            case 3 -> "2학기";
+            case 4 -> "겨울학기";
+            default -> String.valueOf(sem);
+        };
+    }
+
+    // 조회 화면 표시용: 리스크 레벨 -> UI 표시값
+    private String toUiRisk(RiskLevel riskLevel) {
+        if (riskLevel == null) return "";
+        return switch (riskLevel) {
+            case HIGH -> "리스크 선호";
+            case MEDIUM -> "리스크 중립";
+            case LOW -> "리스크 회피";
         };
     }
 

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/request/AiForecastRequestToAi.java
@@ -22,9 +22,9 @@ public record AiForecastRequestToAi(
             @Schema(example = "1")
             @NotNull String semester, //1=1학기,2=여름학기,3=2학기,4=겨울학기
 
-            @JsonProperty("org_cd")
-            @Schema(example = "7008277")
-            @NotBlank String campus, //org_cd
+            @JsonProperty("campus")
+            @Schema(example = "한양대학교 ERICA캠퍼스")
+            @NotBlank String campus, //AI 서버는 conditions.campus(조직명)로 ERICA 캠퍼스 필터링
 
             @JsonProperty("dept_name")
             @JsonAlias({"department"})

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/response/AiForecastResponse.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/response/AiForecastResponse.java
@@ -53,6 +53,7 @@ public record AiForecastResponse(
     ) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record RecommendationItemRaw(
             @JsonProperty("id")
             Long id,
@@ -65,7 +66,19 @@ public record AiForecastResponse(
             @JsonProperty("estimated_budget")
             Number estimatedBudget, //예상 예산 (총합)
             @JsonProperty("recommend_order_date")
-            String recommendOrderDate //권장 발주 마감 기한
+            String recommendOrderDate, //권장 발주 마감 기한
+            @JsonProperty("base_qty")
+            Number baseQty, //고장 예상 수량 (안전재고 제외)
+            @JsonProperty("safety_stock")
+            Number safetyStock, //안전 재고
+            @JsonProperty("rop")
+            Number rop, //재발주점(ROP)
+            @JsonProperty("lead_time_days")
+            Number leadTimeDays, //조달 리드타임(일)
+            @JsonProperty("monthly_avg_demand")
+            Number monthlyAvgDemand, //월 평균 수요
+            @JsonProperty("ai_analysis_comment")
+            String aiAnalysisComment //AI분석코멘트
     ) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/usto/api/ai/forecast/presentation/dto/response/AiForecastResponse.java
+++ b/src/main/java/com/usto/api/ai/forecast/presentation/dto/response/AiForecastResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record AiForecastResponse(
         @JsonProperty("section_1_time_series")
         List<TimeSeriesPointRaw> section1TimeSeries,
@@ -17,7 +18,21 @@ public record AiForecastResponse(
         List<RecommendationItemRaw> section3Recommendations,
 
         @JsonProperty("section_4_algorithm_guide")
-        AlgorithmGuideRaw section4AlgorithmGuide
+        AlgorithmGuideRaw section4AlgorithmGuide,
+
+        // --- 이전 분석 조회(contents) 화면 상단 영역용 메타. analyze 응답에서는 null이라 직렬화에서 제외됨 ---
+        @JsonProperty("prompt")
+        String prompt, //사용자 질문
+        @JsonProperty("target")
+        String target, //분석 대상(운용부서명 = dept_name)
+        @JsonProperty("risk")
+        String risk, //리스크 표시값(리스크 선호/중립/회피)
+        @JsonProperty("period")
+        String period, //분석 기간 표시값(예: 2030년 2학기)
+        @JsonProperty("campus")
+        String campus, //캠퍼스 조직명
+        @JsonProperty("conditions")
+        ConditionsRaw conditions //분석 조건 원본
 ) {
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -89,5 +104,22 @@ public record AiForecastResponse(
             String formula2, //발주 시점(ROP) 도출 공식 설명
             @JsonProperty("formula_3")
             String formula3 //잔여 수명(RUL) 정의 설명
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ConditionsRaw(
+            @JsonProperty("year")
+            Integer year, //분석 년도
+            @JsonProperty("semester")
+            String semester, //학기 표시값(1학기/여름학기/2학기/겨울학기)
+            @JsonProperty("campus")
+            String campus, //캠퍼스 조직명
+            @JsonProperty("dept_name")
+            String deptName, //운용부서명
+            @JsonProperty("category")
+            String category, //물품분류명
+            @JsonProperty("risk_level")
+            String riskLevel //리스크 레벨(LOW/MEDIUM/HIGH)
     ) {}
 }


### PR DESCRIPTION
## 배경
프론트 팀에서 이전 분석 조회 응답에 일부 필드가 누락된다는 코멘트가 와서, 백엔드 코드를 점검하고 데이터 손실 원인을 수정했습니다.

**근본 원인:** AI 응답을 받는 즉시 `AiForecastResponse` DTO로 역직렬화하는데(`AiForecastAdapter`), 이 DTO에 없는 필드는 `@JsonIgnoreProperties(ignoreUnknown = true)`에 의해 **저장되기도 전에 조용히 버려집니다.** DB에는 이미 걸러진 JSON이 저장되므로 조회에서도 복원되지 않습니다.

## 변경 사항

### 1. `section_3_recommendations` 누락 필드 추가 (코멘트 #2, #4)
`RecommendationItemRaw`에 `base_qty`, `safety_stock`, `rop`, `lead_time_days`, `monthly_avg_demand`, `ai_analysis_comment` 추가. DTO에 필드가 생기면 저장/조회 경로 모두 보존됩니다.

### 2. AI 호출 시 campus 키 수정 (코멘트 #3)
`AiForecastRequestToAi`의 조직 필드를 `org_cd` -> `campus` 로 변경. AI 서버가 `conditions.campus`로 ERICA 캠퍼스 필터링하도록 바뀐 스펙에 맞춤.

### 3. 이전 분석 조회 응답에 상단 메타 추가 (코멘트 #1)
이전 분석 결과 화면 상단이 비어 보이던 문제 해결. **데이터는 이미 엔티티 컬럼에 저장돼 있어** 조회(`contents/{forecastId}`) 응답 DTO만 확장했습니다 (DB 마이그레이션 없음).

- `AiForecastResponse`에 `prompt`, `target`, `risk`, `period`, `campus`, `conditions` 추가 (`@JsonInclude(NON_NULL)`로 analyze 응답에서는 미출력)
- `check()`에서 저장된 조건 컬럼 + org/dept 코드를 표시값으로 변환:
  - `target` = 운용부서명(`dept_name`) — U-sto_FE의 `operatingDept`와 동일 의미
  - `risk` = 리스크 선호/중립/회피, `period` = `"{year}년 {학기라벨}"`
  - 포맷은 **U-sto_FE 라이브 분석 화면(`displaySummary`) 기준**에 맞춤
  - `conditions` = { year, semester(라벨), campus(조직명), dept_name, category, risk_level(LOW/MEDIUM/HIGH) }

> 참고: FE의 `fetchAiForecastHistoryDetail`은 현재 displaySummary 없이 매핑하므로, 화면에 실제로 그리려면 **FE에서 `data.target/risk/period/conditions`를 읽도록 함께 수정**이 필요합니다(백엔드는 값 제공 완료).

## 조치 불필요로 확인된 항목

- **코멘트 #5 (저장 구조):** 이미 `forecastId`만이 아니라 섹션 JSON 전체를 `LONGTEXT` 컬럼에 저장 중이라 AI 서버 재시작과 무관하게 이력 유지됨. (단, 저장되는 건 원본이 아닌 DTO로 한 번 거른 JSON)
- **코멘트 #6 (권장발주기한 보정):** 백엔드에 `recommend_order_date`를 오늘 날짜로 보정하는 로직 **없음.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)